### PR TITLE
Bump s6 overlay from 2.2.0.0 to 2.2.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG NEXTCLOUDTAG="20-fpm"
 FROM nextcloud:${NEXTCLOUDTAG}
 
 # Set S6-Overlay version
-ARG ARG_S6_OVERLAY_VERSION="2.2.0.0"
+ARG ARG_S6_OVERLAY_VERSION="2.2.0.3"
 
 # Basic build-time metadata as defined at http://label-schema.org
 LABEL \


### PR DESCRIPTION
Closing #7 Bump s6 overlay from 2.2.0.0 to 2.2.0.3